### PR TITLE
Add menu states and CRT controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - MonoGame 3.8.2 DesktopGL project configured for 1600x900 rendering
 - Lightweight ECS with input, movement, shooting, bullet, parallax, render, and HUD systems
 - Deterministic randomization for repeatable bullet patterns
+- Start, pause, and game-over overlays that surface core controls at a glance
+- Configurable CRT post-processing with runtime toggle and intensity controls
 - Content pipeline with procedural placeholder art, a system font sprite font, and CRT shader stub
 - Packaging script for producing a distributable Windows build
 
@@ -21,6 +23,41 @@
 ```
 
 The game launches with a scrolling parallax starfield, a controllable player ship, and a simple HUD displaying FPS, lives, and score.
+
+## Gameplay controls
+
+- **Move**: WASD / Arrow Keys / Left Stick
+- **Fire**: Space / A / Right Shoulder
+- **Focus**: Left or Right Shift / Right Trigger
+- **Pause / Resume**: Esc / Start
+- **Confirm menus**: Enter / A
+- **Toggle CRT**: C / Y
+- **Adjust CRT intensity**: `[ ]` keys / D-Pad Left & Right
+- **Exit**: Q / Back
+
+## Contributor setup
+
+- Install .NET 8 SDK and MonoGame Content Builder (`dotnet tool install dotnet-mgcb-editor`).
+- Clone this repository and initialize submodules (none today, but the command is provided for future use).
+- Run `dotnet restore` and `dotnet build` from the repository root to validate your environment.
+- Launch the game with `dotnet run --project src/Game` to confirm graphics and input function locally.
+- Use an editor with C# analyzers enabled; nullability warnings help catch ECS wiring mistakes early.
+
+## Content pipeline workflow
+
+- Edit assets under `src/Content` and register them inside `Content.mgcb` using the MonoGame Content Builder.
+- Run `dotnet mgcb-editor` for a GUI, or `dotnet mgcb /@:src/Content/Content.mgcb /build` for headless builds.
+- Keep large binary assets out of Git; prefer procedural placeholders or pack them via release artifacts.
+- Update `TextureFactory` helpers when swapping placeholder sprites to ensure runtime generation remains deterministic.
+- After adding new content, rebuild the project to ensure the asset pipeline compiles without errors.
+
+## Release checklist
+
+- Bump the version and changelog entries to reflect the feature set included in the build.
+- Run `dotnet clean` and `dotnet build -c Release` to generate optimized binaries for verification.
+- Execute smoke tests on Windows, macOS (via Metal ANGLE), and Linux to confirm controller and keyboard input paths.
+- Package the game with `pwsh tools/pack-win/pack.ps1` (and equivalent scripts per platform) into the `dist/` folder.
+- Capture fresh screenshots and short gameplay clips for marketing updates and store page refreshes.
 
 ## Tooling
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,14 +7,12 @@
 - Provide power-up drops that enhance fire rate, spread, or grant shields.
 
 ## Player Experience
-- Create start, pause, and game-over screens with clear controls and feedback.
 - Implement audio cues for shooting, explosions, UI interactions, and background music.
 - Expand HUD with health, power-up status, and objective messaging.
 
 ## Content & Visuals
 - Replace placeholder sprites with themed player, enemy, projectile, and background art.
 - Add screen shake, hit flashes, and particle effects for combat feedback.
-- Integrate CRT post-processing shader toggle with configurable intensity.
 
 ## Progression & Scoring
 - Track score multipliers, combos, and persistent high-score table.
@@ -24,7 +22,6 @@
 ## Tooling & QA
 - Set up automated gameplay smoke test that validates launch and basic movement.
 - Add unit or integration tests for critical ECS systems (input, movement, collision).
-- Document contributor setup, content pipeline workflow, and release checklist.
 
 ## Release Readiness
 - Package cross-platform builds (Windows, macOS, Linux) with instructions.

--- a/src/Content/Shaders/CRT.fx
+++ b/src/Content/Shaders/CRT.fx
@@ -1,8 +1,35 @@
 sampler TextureSampler : register(s0);
 
+float CRTIntensity = 0.0f;
+float2 TextureSize = float2(1600.0f, 900.0f);
+
 float4 MainPS(float4 position : SV_POSITION, float4 color : COLOR0, float2 texCoord : TEXCOORD0) : SV_TARGET
 {
-    return tex2D(TextureSampler, texCoord) * color;
+    float4 sample = tex2D(TextureSampler, texCoord) * color;
+    float3 rgb = sample.rgb;
+    float alpha = sample.a;
+
+    float intensity = saturate(CRTIntensity);
+    float extra = max(CRTIntensity - 1.0f, 0.0f);
+
+    float2 centered = texCoord * 2.0f - 1.0f;
+    float dist = dot(centered, centered);
+    float vignette = saturate(1.0f - 0.35f * dist);
+
+    float scan = 1.0f;
+    if (TextureSize.y > 0.0f)
+    {
+        float wave = sin(texCoord.y * TextureSize.y * 3.14159265f);
+        scan = saturate(1.0f - 0.18f * wave * wave);
+    }
+
+    float attenuation = vignette * scan;
+    float3 modulated = lerp(rgb, rgb * attenuation, intensity);
+    float glowStrength = 0.08f * intensity + 0.12f * extra;
+    float3 glow = rgb * glowStrength;
+
+    float3 finalColor = saturate(modulated + glow);
+    return float4(finalColor, alpha);
 }
 
 technique Technique1

--- a/src/Game/Core/ComponentStore.cs
+++ b/src/Game/Core/ComponentStore.cs
@@ -40,6 +40,21 @@ public sealed class ComponentStore
     }
 
     /// <summary>
+    /// Removes all entities and components, resetting the store to its initial state.
+    /// </summary>
+    public void Clear()
+    {
+        _entities.Clear();
+        foreach (var store in _components.Values)
+        {
+            var dictionary = (Dictionary<int, object>)store;
+            dictionary.Clear();
+        }
+
+        _nextEntityId = 1;
+    }
+
+    /// <summary>
     /// Adds or replaces the component on the given entity.
     /// </summary>
     public void Add<T>(Entity entity, T component) where T : class

--- a/src/Game/Game1.cs
+++ b/src/Game/Game1.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using LifeForce.Components;
 using LifeForce.Core;
 using LifeForce.Graphics;
@@ -11,6 +12,14 @@ namespace LifeForce;
 
 public class Game1 : Game
 {
+    private enum GameState
+    {
+        Start,
+        Playing,
+        Paused,
+        GameOver
+    }
+
     private readonly GraphicsDeviceManager _graphics;
     private SpriteBatch? _spriteBatch;
 
@@ -18,9 +27,20 @@ public class Game1 : Game
     private readonly InputMap _inputMap = new();
     private readonly Random _rng = new(20250214);
 
+    private const float CrtIntensityMin = 0f;
+    private const float CrtIntensityMax = 1.5f;
+    private const float CrtIntensityStep = 0.1f;
+
+    private GameState _state = GameState.Start;
+    private float _stateTimer = 0f;
+
+    private bool _crtEnabled = true;
+    private float _crtIntensity = 0.75f;
+
     private Texture2D? _starTexture;
     private Texture2D? _playerTexture;
     private Texture2D? _bulletTexture;
+    private Texture2D? _pixelTexture;
     private SpriteFont? _font;
     private Effect? _crtEffect;
 
@@ -67,10 +87,15 @@ public class Game1 : Game
         var font = Content.Load<SpriteFont>("Fonts/Arcade");
         _crtEffect = TryLoadEffect("Shaders/CRT");
 
+        _pixelTexture = new Texture2D(GraphicsDevice, 1, 1);
+        _pixelTexture.SetData(new[] { Color.White });
+
         _starTexture = starTexture;
         _playerTexture = playerTexture;
         _bulletTexture = bulletTexture;
         _font = font;
+
+        ApplyCrtSettings();
 
         _parallaxSystem = new ParallaxSystem(starTexture, new Point(_graphics.PreferredBackBufferWidth, _graphics.PreferredBackBufferHeight));
         _inputSystem = new InputSystem();
@@ -79,7 +104,8 @@ public class Game1 : Game
         _bulletSystem = new BulletSystem(_store, new Rectangle(-256, -256, _graphics.PreferredBackBufferWidth + 512, _graphics.PreferredBackBufferHeight + 512));
         _hudSystem = new HUDSystem(font);
 
-        CreatePlayer();
+        ResetWorld();
+        ChangeState(GameState.Start);
     }
 
     private void CreatePlayer()
@@ -125,19 +151,64 @@ public class Game1 : Game
         _fpsDisplay = MathHelper.Lerp(_fpsDisplay, fpsInstant, 0.1f);
 
         _inputMap.Update();
+        HandlePostProcessingInput();
 
-        _parallaxSystem?.Update(dt);
-        _inputSystem?.Update(_store, _inputMap, dt);
-
-        if (_inputSystem?.ExitRequested == true)
+        if (_inputMap.ExitPressed)
         {
             Exit();
             return;
         }
 
-        _movementSystem?.Update(_store, dt);
-        _shootingSystem?.Update(_inputMap, dt);
-        _bulletSystem?.Update(dt);
+        _stateTimer += dt;
+
+        _parallaxSystem?.Update(dt);
+
+        switch (_state)
+        {
+            case GameState.Start:
+                if (_inputMap.MenuConfirmPressed)
+                {
+                    StartNewGame();
+                }
+
+                break;
+            case GameState.Playing:
+                if (_inputMap.PausePressed)
+                {
+                    ChangeState(GameState.Paused);
+                    break;
+                }
+
+                if (UpdateGameplay(dt))
+                {
+                    return;
+                }
+
+                if (!PlayerAlive())
+                {
+                    ChangeState(GameState.GameOver);
+                }
+
+                break;
+            case GameState.Paused:
+                if (_inputMap.PausePressed)
+                {
+                    ChangeState(GameState.Playing);
+                }
+                else if (_inputMap.MenuConfirmPressed)
+                {
+                    StartNewGame();
+                }
+
+                break;
+            case GameState.GameOver:
+                if (_inputMap.MenuConfirmPressed)
+                {
+                    StartNewGame();
+                }
+
+                break;
+        }
 
         base.Update(gameTime);
     }
@@ -151,17 +222,184 @@ public class Game1 : Game
             return;
         }
 
+        ApplyCrtSettings();
         _spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, null, null, _crtEffect);
 
         _parallaxSystem?.Draw(_spriteBatch);
         _renderSystem.Draw(_store, _spriteBatch);
 
-        var lives = GetPlayerLives();
-        _hudSystem?.Draw(_spriteBatch, _fpsDisplay, lives, _score);
+        if (_state == GameState.Playing)
+        {
+            var lives = GetPlayerLives();
+            _hudSystem?.Draw(_spriteBatch, _fpsDisplay, lives, _score);
+        }
+
+        DrawOverlay(_spriteBatch);
 
         _spriteBatch.End();
 
         base.Draw(gameTime);
+    }
+
+    private bool UpdateGameplay(float dt)
+    {
+        _inputSystem?.Update(_store, _inputMap, dt);
+
+        if (_inputSystem?.ExitRequested == true)
+        {
+            Exit();
+            return true;
+        }
+
+        _movementSystem?.Update(_store, dt);
+        _shootingSystem?.Update(_inputMap, dt);
+        _bulletSystem?.Update(dt);
+        return false;
+    }
+
+    private bool PlayerAlive()
+    {
+        if (_playerEntity.IsValid && _store.TryGet(_playerEntity, out HealthComponent? health) && health is not null)
+        {
+            return health.Current > 0;
+        }
+
+        return false;
+    }
+
+    private void ResetWorld()
+    {
+        _playerEntity = Entity.Invalid;
+        _store.Clear();
+        CreatePlayer();
+        _score = 0;
+        _shootingSystem?.Reset();
+    }
+
+    private void StartNewGame()
+    {
+        ResetWorld();
+        ChangeState(GameState.Playing);
+    }
+
+    private void ChangeState(GameState newState)
+    {
+        _state = newState;
+        _stateTimer = 0f;
+    }
+
+    private void HandlePostProcessingInput()
+    {
+        var changed = false;
+
+        if (_inputMap.ToggleCrtPressed)
+        {
+            _crtEnabled = !_crtEnabled;
+            changed = true;
+        }
+
+        if (_inputMap.IncreaseCrtPressed)
+        {
+            _crtIntensity = MathHelper.Clamp(_crtIntensity + CrtIntensityStep, CrtIntensityMin, CrtIntensityMax);
+            changed = true;
+        }
+
+        if (_inputMap.DecreaseCrtPressed)
+        {
+            _crtIntensity = MathHelper.Clamp(_crtIntensity - CrtIntensityStep, CrtIntensityMin, CrtIntensityMax);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            ApplyCrtSettings();
+        }
+    }
+
+    private void ApplyCrtSettings()
+    {
+        if (_crtEffect is null)
+        {
+            return;
+        }
+
+        var intensity = _crtEnabled ? MathHelper.Clamp(_crtIntensity, CrtIntensityMin, CrtIntensityMax) : 0f;
+        _crtEffect.Parameters["CRTIntensity"]?.SetValue(intensity);
+        _crtEffect.Parameters["TextureSize"]?.SetValue(new Vector2(_graphics.PreferredBackBufferWidth, _graphics.PreferredBackBufferHeight));
+    }
+
+    private void DrawOverlay(SpriteBatch spriteBatch)
+    {
+        if (_font is null || _state == GameState.Playing)
+        {
+            return;
+        }
+
+        var viewport = GraphicsDevice.Viewport;
+
+        if (_pixelTexture is not null)
+        {
+            var alpha = _state == GameState.Start ? 0.55f : 0.7f;
+            var rectangle = new Rectangle(0, 0, viewport.Width, viewport.Height);
+            spriteBatch.Draw(_pixelTexture, rectangle, Color.Black * alpha);
+        }
+
+        var lines = new List<(string text, Color color)>();
+
+        switch (_state)
+        {
+            case GameState.Start:
+                lines.Add(("LIFEFORCE 2025", Color.Cyan));
+                lines.Add(("Press Enter / A to launch", GetPulseColor(Color.White, Color.Cyan)));
+                lines.Add(("Move with WASD or Left Stick · Fire with Space / A", Color.White));
+                lines.Add(("Hold Shift / Right Trigger to focus movement", Color.White));
+                break;
+            case GameState.Paused:
+                lines.Add(("Paused", Color.Cyan));
+                lines.Add(("Press Esc / Start to resume", Color.White));
+                lines.Add(("Press Enter / A to restart from the hangar", Color.White));
+                break;
+            case GameState.GameOver:
+                lines.Add(("Game Over", Color.Crimson));
+                lines.Add(("Press Enter / A to try again", GetPulseColor(Color.White, Color.OrangeRed)));
+                break;
+        }
+
+        var crtStatus = $"CRT {( _crtEnabled ? "ON" : "OFF")} · Intensity {_crtIntensity:0.0}";
+        lines.Add((crtStatus, Color.White));
+        lines.Add(("Press C / Y to toggle CRT · [ / ] or D-Pad Left/Right adjust", Color.White));
+        lines.Add(("Press Q or Back to exit", Color.White));
+
+        var totalHeight = lines.Count * _font.LineSpacing;
+        var startY = viewport.Height * 0.5f - totalHeight * 0.5f;
+        var y = startY;
+
+        foreach (var (text, color) in lines)
+        {
+            DrawCenteredString(spriteBatch, text, y, color);
+            y += _font.LineSpacing;
+        }
+    }
+
+    private Color GetPulseColor(Color baseColor, Color highlight)
+    {
+        var pulse = 0.5f + 0.5f * MathF.Sin(_stateTimer * 4f);
+        return Color.Lerp(baseColor, highlight, pulse);
+    }
+
+    private void DrawCenteredString(SpriteBatch spriteBatch, string text, float y, Color color)
+    {
+        if (_font is null)
+        {
+            return;
+        }
+
+        var viewport = GraphicsDevice.Viewport;
+        var size = _font.MeasureString(text);
+        var position = new Vector2(viewport.Width * 0.5f - size.X * 0.5f, y);
+        var shadowOffset = new Vector2(2f, 2f);
+        spriteBatch.DrawString(_font, text, position + shadowOffset, Color.Black * 0.6f);
+        spriteBatch.DrawString(_font, text, position, color);
     }
 
     private int GetPlayerLives()
@@ -172,7 +410,7 @@ public class Game1 : Game
         }
 
         return 3;
-}
+    }
 
     private Effect? TryLoadEffect(string assetName)
     {

--- a/src/Game/Input/InputMap.cs
+++ b/src/Game/Input/InputMap.cs
@@ -67,7 +67,17 @@ public sealed class InputMap
 
     public bool FirePressed => WasKeyJustPressed(Keys.Space) || WasButtonJustPressed(Buttons.A) || WasButtonJustPressed(Buttons.RightShoulder);
 
-    public bool ExitPressed => WasKeyJustPressed(Keys.Escape) || WasButtonJustPressed(Buttons.Back) || WasButtonJustPressed(Buttons.Start);
+    public bool PausePressed => WasKeyJustPressed(Keys.Escape) || WasButtonJustPressed(Buttons.Start);
+
+    public bool MenuConfirmPressed => WasKeyJustPressed(Keys.Enter) || WasButtonJustPressed(Buttons.A);
+
+    public bool ExitPressed => WasKeyJustPressed(Keys.Q) || WasButtonJustPressed(Buttons.Back);
+
+    public bool ToggleCrtPressed => WasKeyJustPressed(Keys.C) || WasButtonJustPressed(Buttons.Y);
+
+    public bool IncreaseCrtPressed => WasKeyJustPressed(Keys.OemCloseBrackets) || WasButtonJustPressed(Buttons.DPadRight);
+
+    public bool DecreaseCrtPressed => WasKeyJustPressed(Keys.OemOpenBrackets) || WasButtonJustPressed(Buttons.DPadLeft);
 
     private static bool IsKeyDown(KeyboardState state, Keys key) => state.IsKeyDown(key);
 

--- a/src/Game/Systems/ShootingSystem.cs
+++ b/src/Game/Systems/ShootingSystem.cs
@@ -49,6 +49,11 @@ public sealed class ShootingSystem
         _cooldown = _fireInterval;
     }
 
+    public void Reset()
+    {
+        _cooldown = 0f;
+    }
+
     private void SpawnBullet(Vector2 origin)
     {
         var variance = ((float)_rng.NextDouble() - 0.5f) * 0.1f;


### PR DESCRIPTION
## Summary
- add a gameplay state machine with start, pause, and game-over overlays plus restart logic
- expose CRT shader toggles and intensity controls through the input map and shader parameters
- document the updated controls and prune the completed roadmap items

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d45303f494832784b1292cbde957e4