### PR TITLE
Add enemy waves and player damage handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - MonoGame 3.8.2 DesktopGL project configured for 1600x900 rendering
 - Lightweight ECS with input, movement, shooting, bullet, parallax, render, and HUD systems
 - Deterministic randomization for repeatable bullet patterns
+- Start, pause, and game-over overlays that surface core controls at a glance
+- Configurable CRT post-processing with runtime toggle and intensity controls
 - Content pipeline with procedural placeholder art, a system font sprite font, and CRT shader stub
 - Packaging script for producing a distributable Windows build
 
@@ -21,6 +23,41 @@
 ```
 
 The game launches with a scrolling parallax starfield, a controllable player ship, and a simple HUD displaying FPS, lives, and score.
+
+## Gameplay controls
+
+- **Move**: WASD / Arrow Keys / Left Stick
+- **Fire**: Space / A / Right Shoulder
+- **Focus**: Left or Right Shift / Right Trigger
+- **Pause / Resume**: Esc / Start
+- **Confirm menus**: Enter / A
+- **Toggle CRT**: C / Y
+- **Adjust CRT intensity**: `[ ]` keys / D-Pad Left & Right
+- **Exit**: Q / Back
+
+## Contributor setup
+
+- Install .NET 8 SDK and MonoGame Content Builder (`dotnet tool install dotnet-mgcb-editor`).
+- Clone this repository and initialize submodules (none today, but the command is provided for future use).
+- Run `dotnet restore` and `dotnet build` from the repository root to validate your environment.
+- Launch the game with `dotnet run --project src/Game` to confirm graphics and input function locally.
+- Use an editor with C# analyzers enabled; nullability warnings help catch ECS wiring mistakes early.
+
+## Content pipeline workflow
+
+- Edit assets under `src/Content` and register them inside `Content.mgcb` using the MonoGame Content Builder.
+- Run `dotnet mgcb-editor` for a GUI, or `dotnet mgcb /@:src/Content/Content.mgcb /build` for headless builds.
+- Keep large binary assets out of Git; prefer procedural placeholders or pack them via release artifacts.
+- Update `TextureFactory` helpers when swapping placeholder sprites to ensure runtime generation remains deterministic.
+- After adding new content, rebuild the project to ensure the asset pipeline compiles without errors.
+
+## Release checklist
+
+- Bump the version and changelog entries to reflect the feature set included in the build.
+- Run `dotnet clean` and `dotnet build -c Release` to generate optimized binaries for verification.
+- Execute smoke tests on Windows, macOS (via Metal ANGLE), and Linux to confirm controller and keyboard input paths.
+- Package the game with `pwsh tools/pack-win/pack.ps1` (and equivalent scripts per platform) into the `dist/` folder.
+- Capture fresh screenshots and short gameplay clips for marketing updates and store page refreshes.
 
 ## Tooling
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,20 +1,15 @@
 # MVP Roadmap
 
 ## Core Gameplay
-- Implement multiple enemy ship behaviors (basic chaser, turret, and formation flyer).
-- Add enemy wave scheduler with escalating difficulty over time.
-- Introduce collision-driven player damage and temporary invulnerability frames.
 - Provide power-up drops that enhance fire rate, spread, or grant shields.
 
 ## Player Experience
-- Create start, pause, and game-over screens with clear controls and feedback.
 - Implement audio cues for shooting, explosions, UI interactions, and background music.
 - Expand HUD with health, power-up status, and objective messaging.
 
 ## Content & Visuals
 - Replace placeholder sprites with themed player, enemy, projectile, and background art.
 - Add screen shake, hit flashes, and particle effects for combat feedback.
-- Integrate CRT post-processing shader toggle with configurable intensity.
 
 ## Progression & Scoring
 - Track score multipliers, combos, and persistent high-score table.
@@ -24,7 +19,6 @@
 ## Tooling & QA
 - Set up automated gameplay smoke test that validates launch and basic movement.
 - Add unit or integration tests for critical ECS systems (input, movement, collision).
-- Document contributor setup, content pipeline workflow, and release checklist.
 
 ## Release Readiness
 - Package cross-platform builds (Windows, macOS, Linux) with instructions.

--- a/src/Content/Shaders/CRT.fx
+++ b/src/Content/Shaders/CRT.fx
@@ -1,8 +1,35 @@
 sampler TextureSampler : register(s0);
 
+float CRTIntensity = 0.0f;
+float2 TextureSize = float2(1600.0f, 900.0f);
+
 float4 MainPS(float4 position : SV_POSITION, float4 color : COLOR0, float2 texCoord : TEXCOORD0) : SV_TARGET
 {
-    return tex2D(TextureSampler, texCoord) * color;
+    float4 sample = tex2D(TextureSampler, texCoord) * color;
+    float3 rgb = sample.rgb;
+    float alpha = sample.a;
+
+    float intensity = saturate(CRTIntensity);
+    float extra = max(CRTIntensity - 1.0f, 0.0f);
+
+    float2 centered = texCoord * 2.0f - 1.0f;
+    float dist = dot(centered, centered);
+    float vignette = saturate(1.0f - 0.35f * dist);
+
+    float scan = 1.0f;
+    if (TextureSize.y > 0.0f)
+    {
+        float wave = sin(texCoord.y * TextureSize.y * 3.14159265f);
+        scan = saturate(1.0f - 0.18f * wave * wave);
+    }
+
+    float attenuation = vignette * scan;
+    float3 modulated = lerp(rgb, rgb * attenuation, intensity);
+    float glowStrength = 0.08f * intensity + 0.12f * extra;
+    float3 glow = rgb * glowStrength;
+
+    float3 finalColor = saturate(modulated + glow);
+    return float4(finalColor, alpha);
 }
 
 technique Technique1

--- a/src/Game/Components/BulletComponent.cs
+++ b/src/Game/Components/BulletComponent.cs
@@ -11,4 +11,5 @@ public sealed class BulletComponent
     public float Speed { get; set; } = 800f;
     public float Lifetime { get; set; } = 2.0f;
     public float Age { get; set; }
+    public bool FromPlayer { get; set; } = true;
 }

--- a/src/Game/Components/EnemyComponent.cs
+++ b/src/Game/Components/EnemyComponent.cs
@@ -1,0 +1,29 @@
+using Microsoft.Xna.Framework;
+
+namespace LifeForce.Components;
+
+/// <summary>
+/// Marks an entity as an enemy and stores behaviour specific state.
+/// </summary>
+public sealed class EnemyComponent
+{
+    public EnemyBehavior Behavior { get; set; } = EnemyBehavior.Chaser;
+    public float Speed { get; set; } = 140f;
+    public float FireRate { get; set; } = 1.0f;
+    public float FireCooldown { get; set; }
+    public int ScoreValue { get; set; } = 100;
+    public Color BulletTint { get; set; } = Color.OrangeRed;
+
+    public Vector2 FormationAnchor { get; set; }
+    public Vector2 FormationOffset { get; set; }
+    public float FormationAmplitude { get; set; } = 40f;
+    public float FormationFrequency { get; set; } = 1.5f;
+    public float FormationPhase { get; set; }
+}
+
+public enum EnemyBehavior
+{
+    Chaser,
+    Turret,
+    Formation
+}

--- a/src/Game/Components/HealthComponent.cs
+++ b/src/Game/Components/HealthComponent.cs
@@ -1,10 +1,14 @@
 namespace LifeForce.Components;
 
 /// <summary>
-/// Tracks hit points for simple HUD reporting.
+/// Tracks hit points for simple HUD reporting and invulnerability windows.
 /// </summary>
 public sealed class HealthComponent
 {
     public int Current { get; set; }
     public int Max { get; set; }
+    public float InvulnerabilityDuration { get; set; }
+    public float InvulnerabilityTimer { get; set; }
+
+    public bool IsInvulnerable => InvulnerabilityTimer > 0f;
 }

--- a/src/Game/Core/ComponentStore.cs
+++ b/src/Game/Core/ComponentStore.cs
@@ -40,6 +40,21 @@ public sealed class ComponentStore
     }
 
     /// <summary>
+    /// Removes all entities and components, resetting the store to its initial state.
+    /// </summary>
+    public void Clear()
+    {
+        _entities.Clear();
+        foreach (var store in _components.Values)
+        {
+            var dictionary = (Dictionary<int, object>)store;
+            dictionary.Clear();
+        }
+
+        _nextEntityId = 1;
+    }
+
+    /// <summary>
     /// Adds or replaces the component on the given entity.
     /// </summary>
     public void Add<T>(Entity entity, T component) where T : class
@@ -99,6 +114,23 @@ public sealed class ComponentStore
         get
         {
             foreach (var id in _entities)
+            {
+                yield return new Entity(id);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates all entities containing the requested components.
+    /// </summary>
+    public IEnumerable<Entity> With<T1>()
+        where T1 : class
+    {
+        var store1 = GetStore<T1>();
+
+        foreach (var id in _entities)
+        {
+            if (store1.ContainsKey(id))
             {
                 yield return new Entity(id);
             }

--- a/src/Game/Game1.cs
+++ b/src/Game/Game1.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using LifeForce.Components;
 using LifeForce.Core;
 using LifeForce.Graphics;
@@ -11,6 +12,14 @@ namespace LifeForce;
 
 public class Game1 : Game
 {
+    private enum GameState
+    {
+        Start,
+        Playing,
+        Paused,
+        GameOver
+    }
+
     private readonly GraphicsDeviceManager _graphics;
     private SpriteBatch? _spriteBatch;
 
@@ -18,9 +27,20 @@ public class Game1 : Game
     private readonly InputMap _inputMap = new();
     private readonly Random _rng = new(20250214);
 
+    private const float CrtIntensityMin = 0f;
+    private const float CrtIntensityMax = 1.5f;
+    private const float CrtIntensityStep = 0.1f;
+
+    private GameState _state = GameState.Start;
+    private float _stateTimer = 0f;
+
+    private bool _crtEnabled = true;
+    private float _crtIntensity = 0.75f;
+
     private Texture2D? _starTexture;
     private Texture2D? _playerTexture;
     private Texture2D? _bulletTexture;
+    private Texture2D? _pixelTexture;
     private SpriteFont? _font;
     private Effect? _crtEffect;
 
@@ -29,12 +49,16 @@ public class Game1 : Game
     private MovementSystem? _movementSystem;
     private ShootingSystem? _shootingSystem;
     private BulletSystem? _bulletSystem;
+    private EnemyWaveSystem? _enemyWaveSystem;
+    private EnemySystem? _enemySystem;
+    private CollisionSystem? _collisionSystem;
     private readonly RenderSystem _renderSystem = new();
     private HUDSystem? _hudSystem;
 
     private Entity _playerEntity = Entity.Invalid;
     private float _fpsDisplay = 60f;
     private int _score = 0;
+    private Rectangle _playArea;
 
     public Game1()
     {
@@ -64,22 +88,35 @@ public class Game1 : Game
         var starTexture = TextureFactory.CreateStarfield(GraphicsDevice);
         var playerTexture = TextureFactory.CreatePlayer(GraphicsDevice);
         var bulletTexture = TextureFactory.CreateBullet(GraphicsDevice);
+        var enemyFighterTexture = TextureFactory.CreateEnemyFighter(GraphicsDevice);
+        var enemyTurretTexture = TextureFactory.CreateEnemyTurret(GraphicsDevice);
         var font = Content.Load<SpriteFont>("Fonts/Arcade");
         _crtEffect = TryLoadEffect("Shaders/CRT");
+
+        _pixelTexture = new Texture2D(GraphicsDevice, 1, 1);
+        _pixelTexture.SetData(new[] { Color.White });
 
         _starTexture = starTexture;
         _playerTexture = playerTexture;
         _bulletTexture = bulletTexture;
         _font = font;
 
+        ApplyCrtSettings();
+
+        _playArea = new Rectangle(0, 0, _graphics.PreferredBackBufferWidth, _graphics.PreferredBackBufferHeight);
+
         _parallaxSystem = new ParallaxSystem(starTexture, new Point(_graphics.PreferredBackBufferWidth, _graphics.PreferredBackBufferHeight));
         _inputSystem = new InputSystem();
-        _movementSystem = new MovementSystem(new Rectangle(0, 0, _graphics.PreferredBackBufferWidth, _graphics.PreferredBackBufferHeight));
+        _movementSystem = new MovementSystem(_playArea);
         _shootingSystem = new ShootingSystem(_store, bulletTexture, _rng);
+        _enemyWaveSystem = new EnemyWaveSystem(_store, enemyFighterTexture, enemyTurretTexture, _rng, _playArea);
+        _enemySystem = new EnemySystem(_store, bulletTexture, _rng, _playArea);
         _bulletSystem = new BulletSystem(_store, new Rectangle(-256, -256, _graphics.PreferredBackBufferWidth + 512, _graphics.PreferredBackBufferHeight + 512));
+        _collisionSystem = new CollisionSystem(_store, _playArea);
         _hudSystem = new HUDSystem(font);
 
-        CreatePlayer();
+        ResetWorld();
+        ChangeState(GameState.Start);
     }
 
     private void CreatePlayer()
@@ -103,7 +140,7 @@ public class Game1 : Game
         };
         var velocity = new VelocityComponent();
         var collider = new ColliderComponent { Size = new Vector2(_playerTexture.Width, _playerTexture.Height) };
-        var health = new HealthComponent { Current = 3, Max = 3 };
+        var health = new HealthComponent { Current = 3, Max = 3, InvulnerabilityDuration = 1.2f };
 
         _store.Add(_playerEntity, transform);
         _store.Add(_playerEntity, sprite);
@@ -125,19 +162,64 @@ public class Game1 : Game
         _fpsDisplay = MathHelper.Lerp(_fpsDisplay, fpsInstant, 0.1f);
 
         _inputMap.Update();
+        HandlePostProcessingInput();
 
-        _parallaxSystem?.Update(dt);
-        _inputSystem?.Update(_store, _inputMap, dt);
-
-        if (_inputSystem?.ExitRequested == true)
+        if (_inputMap.ExitPressed)
         {
             Exit();
             return;
         }
 
-        _movementSystem?.Update(_store, dt);
-        _shootingSystem?.Update(_inputMap, dt);
-        _bulletSystem?.Update(dt);
+        _stateTimer += dt;
+
+        _parallaxSystem?.Update(dt);
+
+        switch (_state)
+        {
+            case GameState.Start:
+                if (_inputMap.MenuConfirmPressed)
+                {
+                    StartNewGame();
+                }
+
+                break;
+            case GameState.Playing:
+                if (_inputMap.PausePressed)
+                {
+                    ChangeState(GameState.Paused);
+                    break;
+                }
+
+                if (UpdateGameplay(dt))
+                {
+                    return;
+                }
+
+                if (!PlayerAlive())
+                {
+                    ChangeState(GameState.GameOver);
+                }
+
+                break;
+            case GameState.Paused:
+                if (_inputMap.PausePressed)
+                {
+                    ChangeState(GameState.Playing);
+                }
+                else if (_inputMap.MenuConfirmPressed)
+                {
+                    StartNewGame();
+                }
+
+                break;
+            case GameState.GameOver:
+                if (_inputMap.MenuConfirmPressed)
+                {
+                    StartNewGame();
+                }
+
+                break;
+        }
 
         base.Update(gameTime);
     }
@@ -151,17 +233,202 @@ public class Game1 : Game
             return;
         }
 
+        ApplyCrtSettings();
         _spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, null, null, _crtEffect);
 
         _parallaxSystem?.Draw(_spriteBatch);
         _renderSystem.Draw(_store, _spriteBatch);
 
-        var lives = GetPlayerLives();
-        _hudSystem?.Draw(_spriteBatch, _fpsDisplay, lives, _score);
+        if (_state == GameState.Playing)
+        {
+            var lives = GetPlayerLives();
+            _hudSystem?.Draw(_spriteBatch, _fpsDisplay, lives, _score);
+        }
+
+        DrawOverlay(_spriteBatch);
 
         _spriteBatch.End();
 
         base.Draw(gameTime);
+    }
+
+    private bool UpdateGameplay(float dt)
+    {
+        _inputSystem?.Update(_store, _inputMap, dt);
+
+        if (_inputSystem?.ExitRequested == true)
+        {
+            Exit();
+            return true;
+        }
+
+        _enemyWaveSystem?.Update(dt);
+
+        var playerPosition = GetPlayerPosition();
+        _enemySystem?.Update(dt, playerPosition);
+
+        _movementSystem?.Update(_store, dt);
+        _shootingSystem?.Update(_inputMap, dt);
+        _bulletSystem?.Update(dt);
+
+        if (_collisionSystem is not null)
+        {
+            var collision = _collisionSystem.Update(dt, _playerEntity);
+            if (collision.ScoreDelta != 0)
+            {
+                _score = Math.Max(0, _score + collision.ScoreDelta);
+            }
+        }
+
+        UpdatePlayerInvulnerabilityVisuals();
+        return false;
+    }
+
+    private bool PlayerAlive()
+    {
+        if (_playerEntity.IsValid && _store.TryGet(_playerEntity, out HealthComponent? health) && health is not null)
+        {
+            return health.Current > 0;
+        }
+
+        return false;
+    }
+
+    private void ResetWorld()
+    {
+        _playerEntity = Entity.Invalid;
+        _store.Clear();
+        CreatePlayer();
+        ResetPlayerVisuals();
+        _score = 0;
+        _shootingSystem?.Reset();
+        _enemyWaveSystem?.Reset();
+    }
+
+    private void StartNewGame()
+    {
+        ResetWorld();
+        ChangeState(GameState.Playing);
+    }
+
+    private void ChangeState(GameState newState)
+    {
+        _state = newState;
+        _stateTimer = 0f;
+    }
+
+    private void HandlePostProcessingInput()
+    {
+        var changed = false;
+
+        if (_inputMap.ToggleCrtPressed)
+        {
+            _crtEnabled = !_crtEnabled;
+            changed = true;
+        }
+
+        if (_inputMap.IncreaseCrtPressed)
+        {
+            _crtIntensity = MathHelper.Clamp(_crtIntensity + CrtIntensityStep, CrtIntensityMin, CrtIntensityMax);
+            changed = true;
+        }
+
+        if (_inputMap.DecreaseCrtPressed)
+        {
+            _crtIntensity = MathHelper.Clamp(_crtIntensity - CrtIntensityStep, CrtIntensityMin, CrtIntensityMax);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            ApplyCrtSettings();
+        }
+    }
+
+    private void ApplyCrtSettings()
+    {
+        if (_crtEffect is null)
+        {
+            return;
+        }
+
+        var intensity = _crtEnabled ? MathHelper.Clamp(_crtIntensity, CrtIntensityMin, CrtIntensityMax) : 0f;
+        _crtEffect.Parameters["CRTIntensity"]?.SetValue(intensity);
+        _crtEffect.Parameters["TextureSize"]?.SetValue(new Vector2(_graphics.PreferredBackBufferWidth, _graphics.PreferredBackBufferHeight));
+    }
+
+    private void DrawOverlay(SpriteBatch spriteBatch)
+    {
+        if (_font is null || _state == GameState.Playing)
+        {
+            return;
+        }
+
+        var viewport = GraphicsDevice.Viewport;
+
+        if (_pixelTexture is not null)
+        {
+            var alpha = _state == GameState.Start ? 0.55f : 0.7f;
+            var rectangle = new Rectangle(0, 0, viewport.Width, viewport.Height);
+            spriteBatch.Draw(_pixelTexture, rectangle, Color.Black * alpha);
+        }
+
+        var lines = new List<(string text, Color color)>();
+
+        switch (_state)
+        {
+            case GameState.Start:
+                lines.Add(("LIFEFORCE 2025", Color.Cyan));
+                lines.Add(("Press Enter / A to launch", GetPulseColor(Color.White, Color.Cyan)));
+                lines.Add(("Move with WASD or Left Stick · Fire with Space / A", Color.White));
+                lines.Add(("Hold Shift / Right Trigger to focus movement", Color.White));
+                break;
+            case GameState.Paused:
+                lines.Add(("Paused", Color.Cyan));
+                lines.Add(("Press Esc / Start to resume", Color.White));
+                lines.Add(("Press Enter / A to restart from the hangar", Color.White));
+                break;
+            case GameState.GameOver:
+                lines.Add(("Game Over", Color.Crimson));
+                lines.Add(("Press Enter / A to try again", GetPulseColor(Color.White, Color.OrangeRed)));
+                break;
+        }
+
+        var crtStatus = $"CRT {( _crtEnabled ? "ON" : "OFF")} · Intensity {_crtIntensity:0.0}";
+        lines.Add((crtStatus, Color.White));
+        lines.Add(("Press C / Y to toggle CRT · [ / ] or D-Pad Left/Right adjust", Color.White));
+        lines.Add(("Press Q or Back to exit", Color.White));
+
+        var totalHeight = lines.Count * _font.LineSpacing;
+        var startY = viewport.Height * 0.5f - totalHeight * 0.5f;
+        var y = startY;
+
+        foreach (var (text, color) in lines)
+        {
+            DrawCenteredString(spriteBatch, text, y, color);
+            y += _font.LineSpacing;
+        }
+    }
+
+    private Color GetPulseColor(Color baseColor, Color highlight)
+    {
+        var pulse = 0.5f + 0.5f * MathF.Sin(_stateTimer * 4f);
+        return Color.Lerp(baseColor, highlight, pulse);
+    }
+
+    private void DrawCenteredString(SpriteBatch spriteBatch, string text, float y, Color color)
+    {
+        if (_font is null)
+        {
+            return;
+        }
+
+        var viewport = GraphicsDevice.Viewport;
+        var size = _font.MeasureString(text);
+        var position = new Vector2(viewport.Width * 0.5f - size.X * 0.5f, y);
+        var shadowOffset = new Vector2(2f, 2f);
+        spriteBatch.DrawString(_font, text, position + shadowOffset, Color.Black * 0.6f);
+        spriteBatch.DrawString(_font, text, position, color);
     }
 
     private int GetPlayerLives()
@@ -172,7 +439,63 @@ public class Game1 : Game
         }
 
         return 3;
-}
+    }
+
+    private Vector2 GetPlayerPosition()
+    {
+        if (_playerEntity.IsValid && _store.TryGet(_playerEntity, out TransformComponent? transform) && transform is not null)
+        {
+            return transform.Position;
+        }
+
+        return new Vector2(_graphics.PreferredBackBufferWidth * 0.5f, _graphics.PreferredBackBufferHeight * 0.5f);
+    }
+
+    private void ResetPlayerVisuals()
+    {
+        if (!_playerEntity.IsValid)
+        {
+            return;
+        }
+
+        if (_store.TryGet(_playerEntity, out SpriteComponent? sprite) && sprite is not null)
+        {
+            sprite.Tint = Color.White;
+        }
+
+        if (_store.TryGet(_playerEntity, out HealthComponent? health) && health is not null)
+        {
+            health.InvulnerabilityTimer = 0f;
+        }
+    }
+
+    private void UpdatePlayerInvulnerabilityVisuals()
+    {
+        if (!_playerEntity.IsValid)
+        {
+            return;
+        }
+
+        if (!_store.TryGet(_playerEntity, out SpriteComponent? sprite) || sprite is null)
+        {
+            return;
+        }
+
+        if (!_store.TryGet(_playerEntity, out HealthComponent? health) || health is null)
+        {
+            return;
+        }
+
+        if (health.InvulnerabilityTimer > 0f)
+        {
+            var pulse = 0.5f + 0.5f * MathF.Sin(_stateTimer * 12f);
+            sprite.Tint = Color.Lerp(Color.White, Color.Cyan, pulse);
+        }
+        else
+        {
+            sprite.Tint = Color.White;
+        }
+    }
 
     private Effect? TryLoadEffect(string assetName)
     {

--- a/src/Game/Graphics/TextureFactory.cs
+++ b/src/Game/Graphics/TextureFactory.cs
@@ -95,6 +95,94 @@ public static class TextureFactory
     }
 
     /// <summary>
+    /// Builds a compact enemy fighter sprite with accent stripes.
+    /// </summary>
+    public static Texture2D CreateEnemyFighter(GraphicsDevice device)
+    {
+        const int size = 28;
+        var texture = new Texture2D(device, size, size);
+        var data = new Color[size * size];
+        var center = size / 2f;
+
+        for (var y = 0; y < size; y++)
+        {
+            for (var x = 0; x < size; x++)
+            {
+                var dx = x - center + 0.5f;
+                var dy = y - center + 0.5f;
+                var distance = MathF.Sqrt(dx * dx + dy * dy);
+                var index = y * size + x;
+
+                var color = Color.Transparent;
+                if (distance < 3f)
+                {
+                    color = new Color(0.2f, 0.2f, 0.25f, 1f);
+                }
+                else if (Math.Abs(dx) < 2.5f && Math.Abs(dy) < 9f)
+                {
+                    color = new Color(0.35f, 0.35f, 0.4f, 1f);
+                }
+                else if (dx > -8f && dx < 8f && Math.Abs(dy) < 4f)
+                {
+                    var t = 1f - Math.Abs(dy) / 4f;
+                    color = new Color(0.6f * t, 0.2f * t, 0.1f, 1f);
+                }
+                else if (dx < -6f && Math.Abs(dy) < 6f)
+                {
+                    color = new Color(0.15f, 0.15f, 0.2f, 1f);
+                }
+
+                data[index] = color;
+            }
+        }
+
+        texture.SetData(data);
+        return texture;
+    }
+
+    /// <summary>
+    /// Generates a heavier turret hull sprite for stationary enemies.
+    /// </summary>
+    public static Texture2D CreateEnemyTurret(GraphicsDevice device)
+    {
+        const int size = 36;
+        var texture = new Texture2D(device, size, size);
+        var data = new Color[size * size];
+        var center = size / 2f;
+
+        for (var y = 0; y < size; y++)
+        {
+            for (var x = 0; x < size; x++)
+            {
+                var dx = x - center + 0.5f;
+                var dy = y - center + 0.5f;
+                var distance = MathF.Sqrt(dx * dx * 0.7f + dy * dy * 1.2f);
+                var index = y * size + x;
+
+                var color = Color.Transparent;
+                if (distance < 4f)
+                {
+                    color = new Color(0.2f, 0.2f, 0.25f, 1f);
+                }
+                else if (distance < 11f)
+                {
+                    var rim = MathHelper.Clamp((distance - 5f) / 6f, 0f, 1f);
+                    color = Color.Lerp(new Color(0.25f, 0.25f, 0.3f, 1f), new Color(0.4f, 0.1f, 0.1f, 1f), rim);
+                }
+                else if (Math.Abs(dy) < 2f && Math.Abs(dx) < 14f)
+                {
+                    color = new Color(0.5f, 0.15f, 0.15f, 1f);
+                }
+
+                data[index] = color;
+            }
+        }
+
+        texture.SetData(data);
+        return texture;
+    }
+
+    /// <summary>
     /// Generates a simple glowing bullet quad.
     /// </summary>
     public static Texture2D CreateBullet(GraphicsDevice device)

--- a/src/Game/Input/InputMap.cs
+++ b/src/Game/Input/InputMap.cs
@@ -67,7 +67,17 @@ public sealed class InputMap
 
     public bool FirePressed => WasKeyJustPressed(Keys.Space) || WasButtonJustPressed(Buttons.A) || WasButtonJustPressed(Buttons.RightShoulder);
 
-    public bool ExitPressed => WasKeyJustPressed(Keys.Escape) || WasButtonJustPressed(Buttons.Back) || WasButtonJustPressed(Buttons.Start);
+    public bool PausePressed => WasKeyJustPressed(Keys.Escape) || WasButtonJustPressed(Buttons.Start);
+
+    public bool MenuConfirmPressed => WasKeyJustPressed(Keys.Enter) || WasButtonJustPressed(Buttons.A);
+
+    public bool ExitPressed => WasKeyJustPressed(Keys.Q) || WasButtonJustPressed(Buttons.Back);
+
+    public bool ToggleCrtPressed => WasKeyJustPressed(Keys.C) || WasButtonJustPressed(Buttons.Y);
+
+    public bool IncreaseCrtPressed => WasKeyJustPressed(Keys.OemCloseBrackets) || WasButtonJustPressed(Buttons.DPadRight);
+
+    public bool DecreaseCrtPressed => WasKeyJustPressed(Keys.OemOpenBrackets) || WasButtonJustPressed(Buttons.DPadLeft);
 
     private static bool IsKeyDown(KeyboardState state, Keys key) => state.IsKeyDown(key);
 

--- a/src/Game/Systems/CollisionSystem.cs
+++ b/src/Game/Systems/CollisionSystem.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using LifeForce.Components;
+using LifeForce.Core;
+using Microsoft.Xna.Framework;
+
+namespace LifeForce.Systems;
+
+/// <summary>
+/// Resolves projectile and body collisions between the player and enemies.
+/// </summary>
+public sealed class CollisionSystem
+{
+    private readonly ComponentStore _store;
+    private readonly Rectangle _playArea;
+    private readonly List<Entity> _destroyedBullets = new();
+    private readonly List<Entity> _destroyedEnemies = new();
+
+    public CollisionSystem(ComponentStore store, Rectangle playArea)
+    {
+        _store = store;
+        _playArea = playArea;
+    }
+
+    public CollisionUpdate Update(float dt, Entity playerEntity)
+    {
+        foreach (var entity in _store.With<HealthComponent>())
+        {
+            var health = _store.Get<HealthComponent>(entity);
+            if (health.InvulnerabilityTimer > 0f)
+            {
+                health.InvulnerabilityTimer = MathF.Max(0f, health.InvulnerabilityTimer - dt);
+            }
+        }
+
+        var scoreDelta = 0;
+        var playerHit = false;
+        HealthComponent? playerHealth = null;
+        ColliderComponent? playerCollider = null;
+        TransformComponent? playerTransform = null;
+
+        if (playerEntity.IsValid)
+        {
+            _store.TryGet(playerEntity, out playerHealth);
+            _store.TryGet(playerEntity, out playerCollider);
+            _store.TryGet(playerEntity, out playerTransform);
+        }
+
+        _destroyedBullets.Clear();
+        _destroyedEnemies.Clear();
+
+        var playerBounds = GetBounds(playerTransform, playerCollider);
+
+        foreach (var bulletEntity in _store.With<BulletComponent, TransformComponent>())
+        {
+            var bullet = _store.Get<BulletComponent>(bulletEntity);
+            var transform = _store.Get<TransformComponent>(bulletEntity);
+            if (!_playArea.Contains(transform.Position))
+            {
+                continue;
+            }
+
+            if (bullet.FromPlayer)
+            {
+                scoreDelta += ProcessPlayerBullet(bulletEntity, transform);
+            }
+            else if (playerHealth is not null && playerCollider is not null && !playerHealth.IsInvulnerable)
+            {
+                var bounds = GetBounds(transform, 8f);
+                if (bounds.Intersects(playerBounds))
+                {
+                    ApplyDamage(playerHealth, 1);
+                    playerHit = true;
+                    _destroyedBullets.Add(bulletEntity);
+                }
+            }
+        }
+
+        if (playerHealth is not null && playerCollider is not null && !playerHealth.IsInvulnerable)
+        {
+            foreach (var enemyEntity in _store.With<EnemyComponent, ColliderComponent>())
+            {
+                if (!_store.TryGet(enemyEntity, out TransformComponent? enemyTransform) || enemyTransform is null)
+                {
+                    continue;
+                }
+
+                var bounds = GetBounds(enemyTransform, _store.Get<ColliderComponent>(enemyEntity));
+                if (bounds.Intersects(playerBounds))
+                {
+                    ApplyDamage(playerHealth, 1);
+                    playerHit = true;
+                    _destroyedEnemies.Add(enemyEntity);
+                }
+            }
+        }
+
+        foreach (var bulletEntity in _destroyedBullets)
+        {
+            _store.DestroyEntity(bulletEntity);
+        }
+
+        foreach (var enemyEntity in _destroyedEnemies)
+        {
+            if (_store.TryGet(enemyEntity, out EnemyComponent? enemy) && enemy is not null)
+            {
+                scoreDelta += enemy.ScoreValue;
+            }
+
+            _store.DestroyEntity(enemyEntity);
+        }
+
+        return new CollisionUpdate(scoreDelta, playerHit);
+    }
+
+    private int ProcessPlayerBullet(Entity bulletEntity, TransformComponent bulletTransform)
+    {
+        var bounds = GetBounds(bulletTransform, 8f);
+        foreach (var enemyEntity in _store.With<EnemyComponent, ColliderComponent>())
+        {
+            if (!_store.TryGet(enemyEntity, out TransformComponent? enemyTransform) || enemyTransform is null)
+            {
+                continue;
+            }
+
+            var enemyBounds = GetBounds(enemyTransform, _store.Get<ColliderComponent>(enemyEntity));
+            if (!bounds.Intersects(enemyBounds))
+            {
+                continue;
+            }
+
+            var health = _store.Get<HealthComponent>(enemyEntity);
+            if (health.InvulnerabilityTimer > 0f)
+            {
+                continue;
+            }
+
+            ApplyDamage(health, 1);
+            _destroyedBullets.Add(bulletEntity);
+
+            if (health.Current <= 0)
+            {
+                _destroyedEnemies.Add(enemyEntity);
+            }
+
+            return 0;
+        }
+
+        return 0;
+    }
+
+    private static void ApplyDamage(HealthComponent health, int amount)
+    {
+        health.Current = Math.Max(0, health.Current - amount);
+        health.InvulnerabilityTimer = health.InvulnerabilityDuration;
+    }
+
+    private static Rectangle GetBounds(TransformComponent? transform, ColliderComponent? collider)
+    {
+        if (transform is null || collider is null)
+        {
+            return Rectangle.Empty;
+        }
+
+        var half = collider.Size * 0.5f;
+        return new Rectangle(
+            (int)(transform.Position.X - half.X),
+            (int)(transform.Position.Y - half.Y),
+            (int)collider.Size.X,
+            (int)collider.Size.Y);
+    }
+
+    private static Rectangle GetBounds(TransformComponent? transform, float radius)
+    {
+        if (transform is null)
+        {
+            return Rectangle.Empty;
+        }
+
+        var size = (int)(radius * 2f);
+        return new Rectangle(
+            (int)(transform.Position.X - radius),
+            (int)(transform.Position.Y - radius),
+            size,
+            size);
+    }
+}
+
+public readonly record struct CollisionUpdate(int ScoreDelta, bool PlayerHit);

--- a/src/Game/Systems/EnemySystem.cs
+++ b/src/Game/Systems/EnemySystem.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using LifeForce.Components;
+using LifeForce.Core;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LifeForce.Systems;
+
+/// <summary>
+/// Updates enemy movement behaviours and handles turret firing logic.
+/// </summary>
+public sealed class EnemySystem
+{
+    private readonly ComponentStore _store;
+    private readonly Texture2D _bulletTexture;
+    private readonly Random _rng;
+    private readonly Rectangle _playArea;
+    private readonly List<Entity> _toRemove = new();
+
+    public EnemySystem(ComponentStore store, Texture2D bulletTexture, Random rng, Rectangle playArea)
+    {
+        _store = store;
+        _bulletTexture = bulletTexture;
+        _rng = rng;
+        _playArea = playArea;
+    }
+
+    public void Update(float dt, Vector2 playerPosition)
+    {
+        _toRemove.Clear();
+
+        foreach (var entity in _store.With<EnemyComponent, TransformComponent>())
+        {
+            var enemy = _store.Get<EnemyComponent>(entity);
+            var transform = _store.Get<TransformComponent>(entity);
+            var velocity = _store.TryGet(entity, out VelocityComponent? vel) && vel is not null
+                ? vel
+                : CreateVelocity(entity);
+
+            switch (enemy.Behavior)
+            {
+                case EnemyBehavior.Chaser:
+                    UpdateChaser(enemy, transform, velocity, playerPosition);
+                    break;
+                case EnemyBehavior.Turret:
+                    UpdateTurret(enemy, transform, playerPosition, dt);
+                    velocity.Velocity = Vector2.Zero;
+                    break;
+                case EnemyBehavior.Formation:
+                    UpdateFormation(enemy, transform, velocity, dt);
+                    break;
+            }
+
+            if (transform.Position.X < _playArea.Left - 160f || transform.Position.Y > _playArea.Bottom + 200f || transform.Position.Y < _playArea.Top - 200f)
+            {
+                _toRemove.Add(entity);
+            }
+        }
+
+        foreach (var entity in _toRemove)
+        {
+            _store.DestroyEntity(entity);
+        }
+    }
+
+    private static void UpdateChaser(EnemyComponent enemy, TransformComponent transform, VelocityComponent velocity, Vector2 playerPosition)
+    {
+        var toPlayer = playerPosition - transform.Position;
+        if (toPlayer.LengthSquared() < 1f)
+        {
+            velocity.Velocity = Vector2.Zero;
+            return;
+        }
+
+        toPlayer.Normalize();
+        velocity.Velocity = toPlayer * enemy.Speed;
+    }
+
+    private void UpdateTurret(EnemyComponent enemy, TransformComponent transform, Vector2 playerPosition, float dt)
+    {
+        enemy.FireCooldown -= dt;
+        if (enemy.FireCooldown > 0f)
+        {
+            return;
+        }
+
+        var toPlayer = playerPosition - transform.Position;
+        if (toPlayer.LengthSquared() < 16f)
+        {
+            enemy.FireCooldown = 1f / MathF.Max(enemy.FireRate, 0.1f);
+            return;
+        }
+
+        toPlayer.Normalize();
+        SpawnEnemyBullet(transform.Position + toPlayer * 12f, toPlayer * 520f, enemy.BulletTint);
+        var cadenceVariance = 0.15f + (float)_rng.NextDouble() * 0.2f;
+        enemy.FireCooldown = cadenceVariance + 1f / MathF.Max(enemy.FireRate, 0.2f);
+    }
+
+    private static void UpdateFormation(EnemyComponent enemy, TransformComponent transform, VelocityComponent velocity, float dt)
+    {
+        enemy.FormationAnchor.X -= enemy.Speed * dt;
+        enemy.FormationPhase += enemy.FormationFrequency * dt;
+        var sine = MathF.Sin(enemy.FormationPhase + enemy.FormationOffset.Y) * enemy.FormationAmplitude;
+        var target = enemy.FormationAnchor + new Vector2(enemy.FormationOffset.X, sine);
+        var desired = target - transform.Position;
+        velocity.Velocity = desired * 4.2f;
+    }
+
+    private VelocityComponent CreateVelocity(Entity entity)
+    {
+        var velocity = new VelocityComponent();
+        _store.Add(entity, velocity);
+        return velocity;
+    }
+
+    private void SpawnEnemyBullet(Vector2 origin, Vector2 velocity, Color tint)
+    {
+        var bulletEntity = _store.CreateEntity();
+        var transform = new TransformComponent
+        {
+            Position = origin,
+            Scale = Vector2.One
+        };
+        var sprite = new SpriteComponent
+        {
+            Texture = _bulletTexture,
+            Origin = new Vector2(_bulletTexture.Width / 2f, _bulletTexture.Height / 2f),
+            Tint = tint
+        };
+        var bulletVelocity = new VelocityComponent
+        {
+            Velocity = velocity
+        };
+        var direction = velocity;
+        if (direction.LengthSquared() > 0f)
+        {
+            direction.Normalize();
+        }
+        var bullet = new BulletComponent
+        {
+            Direction = direction,
+            Speed = velocity.Length(),
+            Lifetime = 4.5f,
+            Age = 0f,
+            FromPlayer = false
+        };
+
+        _store.Add(bulletEntity, transform);
+        _store.Add(bulletEntity, sprite);
+        _store.Add(bulletEntity, bulletVelocity);
+        _store.Add(bulletEntity, bullet);
+    }
+}

--- a/src/Game/Systems/EnemyWaveSystem.cs
+++ b/src/Game/Systems/EnemyWaveSystem.cs
@@ -1,0 +1,165 @@
+using System;
+using LifeForce.Components;
+using LifeForce.Core;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace LifeForce.Systems;
+
+/// <summary>
+/// Drives the spawning of enemy waves with escalating difficulty.
+/// </summary>
+public sealed class EnemyWaveSystem
+{
+    private readonly ComponentStore _store;
+    private readonly Texture2D _fighterTexture;
+    private readonly Texture2D _turretTexture;
+    private readonly Random _rng;
+    private readonly Rectangle _playArea;
+
+    private float _timeSinceLastWave;
+    private float _nextWaveDelay = 4.5f;
+    private int _waveIndex;
+
+    public EnemyWaveSystem(ComponentStore store, Texture2D fighterTexture, Texture2D turretTexture, Random rng, Rectangle playArea)
+    {
+        _store = store;
+        _fighterTexture = fighterTexture;
+        _turretTexture = turretTexture;
+        _rng = rng;
+        _playArea = playArea;
+    }
+
+    public void Reset()
+    {
+        _timeSinceLastWave = 0f;
+        _waveIndex = 0;
+        _nextWaveDelay = 4.5f;
+    }
+
+    public void Update(float dt)
+    {
+        _timeSinceLastWave += dt;
+        if (_timeSinceLastWave < _nextWaveDelay)
+        {
+            return;
+        }
+
+        SpawnWave();
+        _timeSinceLastWave = 0f;
+        _waveIndex++;
+        _nextWaveDelay = MathF.Max(1.8f, 4.5f - _waveIndex * 0.35f);
+    }
+
+    private void SpawnWave()
+    {
+        var roll = _waveIndex % 3;
+        switch (roll)
+        {
+            case 0:
+                SpawnChaserWave();
+                break;
+            case 1:
+                SpawnTurretScreen();
+                break;
+            default:
+                SpawnFormationWave();
+                break;
+        }
+    }
+
+    private void SpawnChaserWave()
+    {
+        var count = 3 + _waveIndex / 2;
+        for (var i = 0; i < count; i++)
+        {
+            var spawnY = MathHelper.Lerp(_playArea.Top + 80f, _playArea.Bottom - 80f, (float)_rng.NextDouble());
+            var spawnX = _playArea.Right + 80f + i * 40f;
+            CreateEnemy(new Vector2(spawnX, spawnY), EnemyBehavior.Chaser, _fighterTexture, Color.OrangeRed, speed: 160f + _waveIndex * 8f, scoreValue: 125);
+        }
+    }
+
+    private void SpawnTurretScreen()
+    {
+        var rows = 2 + _waveIndex / 3;
+        var columns = 2;
+        var spacing = new Vector2(96f, 140f);
+        var baseX = _playArea.Right - 200f;
+        var baseY = _playArea.Top + 160f;
+
+        for (var r = 0; r < rows; r++)
+        {
+            for (var c = 0; c < columns; c++)
+            {
+                var offset = new Vector2(-c * spacing.X, r * spacing.Y);
+                var spawn = new Vector2(baseX, baseY) + offset;
+                CreateEnemy(spawn, EnemyBehavior.Turret, _turretTexture, Color.Crimson, fireRate: 1.5f + _waveIndex * 0.1f, scoreValue: 200);
+            }
+        }
+    }
+
+    private void SpawnFormationWave()
+    {
+        var fighters = 5 + _waveIndex;
+        var start = new Vector2(_playArea.Right + 60f, _playArea.Top + 140f + (float)_rng.NextDouble() * (_playArea.Height - 280f));
+        var spacingX = -48f;
+        var spacingY = 22f;
+
+        for (var i = 0; i < fighters; i++)
+        {
+            var column = i % 5;
+            var row = i / 5;
+            var offset = new Vector2(column * spacingX, row * spacingY);
+            var formationOffset = new Vector2(offset.X, row * 0.8f);
+            var enemy = CreateEnemy(start + offset, EnemyBehavior.Formation, _fighterTexture, Color.Goldenrod, speed: 120f, scoreValue: 90);
+            enemy.FormationAnchor = start;
+            enemy.FormationOffset = formationOffset;
+            enemy.FormationAmplitude = 30f + row * 8f;
+            enemy.FormationFrequency = 1.5f + column * 0.2f;
+            enemy.FormationPhase = (float)_rng.NextDouble() * MathF.Tau;
+        }
+    }
+
+    private EnemyComponent CreateEnemy(Vector2 spawnPosition, EnemyBehavior behavior, Texture2D texture, Color tint, float speed = 140f, float fireRate = 1.5f, int scoreValue = 100)
+    {
+        var entity = _store.CreateEntity();
+        var transform = new TransformComponent
+        {
+            Position = spawnPosition,
+            Scale = Vector2.One
+        };
+        var sprite = new SpriteComponent
+        {
+            Texture = texture,
+            Origin = new Vector2(texture.Width / 2f, texture.Height / 2f),
+            Tint = tint
+        };
+        var collider = new ColliderComponent
+        {
+            Size = new Vector2(texture.Width, texture.Height) * 0.75f
+        };
+        var health = new HealthComponent
+        {
+            Current = behavior == EnemyBehavior.Turret ? 4 : 2,
+            Max = behavior == EnemyBehavior.Turret ? 4 : 2,
+            InvulnerabilityDuration = 0.1f
+        };
+        var enemy = new EnemyComponent
+        {
+            Behavior = behavior,
+            Speed = speed,
+            FireRate = fireRate,
+            FireCooldown = 0.4f + (float)_rng.NextDouble() * 0.6f,
+            BulletTint = tint,
+            ScoreValue = scoreValue
+        };
+
+        _store.Add(entity, transform);
+        _store.Add(entity, sprite);
+        _store.Add(entity, collider);
+        _store.Add(entity, health);
+        _store.Add(entity, enemy);
+        _store.Add(entity, new VelocityComponent());
+        return enemy;
+    }
+}

--- a/src/Game/Systems/ShootingSystem.cs
+++ b/src/Game/Systems/ShootingSystem.cs
@@ -49,6 +49,11 @@ public sealed class ShootingSystem
         _cooldown = _fireInterval;
     }
 
+    public void Reset()
+    {
+        _cooldown = 0f;
+    }
+
     private void SpawnBullet(Vector2 origin)
     {
         var variance = ((float)_rng.NextDouble() - 0.5f) * 0.1f;
@@ -77,7 +82,8 @@ public sealed class ShootingSystem
             Direction = direction,
             Speed = 900f,
             Lifetime = 2.5f,
-            Age = 0f
+            Age = 0f,
+            FromPlayer = true
         };
 
         _store.Add(bulletEntity, bulletTransform);


### PR DESCRIPTION
## Summary
- add reusable enemy components and textures plus systems for chaser, turret, and formation behaviours with escalating waves
- introduce a collision system that handles score awards, bullet cleanup, and player invulnerability frames
- update player/game loop plumbing to drive waves, enemy AI, HUD score, and reset state after deaths while pruning completed TODO items

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d45303f494832784b1292cbde957e4